### PR TITLE
Setup scripts

### DIFF
--- a/Lesson0_BeforeWorkshop/README.md
+++ b/Lesson0_BeforeWorkshop/README.md
@@ -23,6 +23,9 @@ This should cost less than $10, just remember to delete all resources when you'r
 
 ### Step 3: serverless deployments require AWS credentials
 
+#### Option 0:
+Install the [AWS-CLI](SETUP-AWS-CLI.md) and use the `aws configure` command to setup your credentials.
+
 #### Option 1:
 Go to AWS IAM console --> users --> select your user ID --> security credentials tab
 Select: Create Access Key

--- a/Lesson0_BeforeWorkshop/README.md
+++ b/Lesson0_BeforeWorkshop/README.md
@@ -62,9 +62,35 @@ $ export AWS_ACCESS_KEY_ID=<access-key-id>
 $ export AWS_SECRET_ACCESS_KEY=<secret-access-key>
 $ export AWS_SESSION_TOKEN=<session-token>             # this one is optional
 ```
-### Step 4: serverless deployments require some information you may not want to check in to a public repo.  Fill in the information in private.yml.
 
-Here's an example private.yml with the values in the correct format. Specific values will be available during the workshop.
+### Step 4: clone the repo on your local machine
+
+Go to https://github.com/Nordstrom/hello-retail-workshop and fork our Repo, then clone it locally.
+
+From your workshop directory:
+```sh
+$ git clone https://github.com/Nordstrom/hello-retail-workshop.git
+```
+For more information on using github, go to https://help.github.com/articles/fork-a-repo/
+
+
+### Step 5: install serverless node package on your machine.
+
+#### Note: if you are on a VPN and use a proxy, export your proxy to your shell
+```sh
+export proxy=https://your.proxy.com:1234
+```
+
+Regardless, install the serverless.com deployment framework - this will make it easy to deploy serverless components to AWS
+```sh
+# $ sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}
+# Uncomment the above if you have corrupted your file system and are on MacOSX.
+$ npm install -g serverless
+```
+
+### Step 6: serverless deployments require some information you may not want to check in to a public repo.  Fill in the information in private.yml.
+
+There's an example private.yml in the project with the values in the correct format. Specific values will be available during the workshop.
 
 ```yml
 region: us-east-1
@@ -83,30 +109,6 @@ coreStream:
   awslabsRoleArn: arn:aws:iam::${self:custom.private.coreStream.accountId}:role/fanoutRole
 
 ```
-
-### Step 5: install serverless node package on your machine.
-
-#### Note: if you are on a VPN and use a proxy, export your proxy to your shell
-```sh
-export proxy=https://your.proxy.com:1234
-```
-
-Regardless, install the serverless.com deployment framework - this will make it easy to deploy serverless components to AWS
-```sh
-# $ sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}
-# Uncomment the above if you have corrupted your file system and are on MacOSX.
-$ npm install -g serverless
-```
-
-### Step 6: clone the repo on your local machine
-
-Go to https://github.com/Nordstrom/hello-retail-workshop and fork our Repo, then clone it locally.
-
-From your workshop directory:
-```sh
-$ git clone https://github.com/Nordstrom/hello-retail-workshop.git
-```
-For more information on using github, go to https://help.github.com/articles/fork-a-repo/
 
 ### Step 7: choose a unique $STAGE name and set the $REGION for your deployed services
 

--- a/Lesson0_BeforeWorkshop/SETUP-AWS-CLI.md
+++ b/Lesson0_BeforeWorkshop/SETUP-AWS-CLI.md
@@ -1,0 +1,16 @@
+# Installing AWS-CLI
+
+If not already installed, easiest way to get it is via NPM [AWS-CLI on NPM](https://www.npmjs.com/package/aws-cli).
+The AWS-CLI is a tremendously capable tool with which to interface with all the AWS services, but is beyond the scope of this project.
+
+Having set up your `~/.aws/credentials` file for Serverless.com, the AWS-CLI will use that same identity file.
+Use the `AWS_PROFILE` environment variable to select the profile to use when calling the AWS managed services.
+
+The AWS-CLI may also be used to configure the user's credentials stored in the `~/.aws/credentials` file, using the following command:
+
+```
+aws configure
+```
+
+When prompted, enter your AWS *Access Key ID* and your *Secret Access Key* then your optional default region and output format. Once done, that information should persisted under
+ the default profile and will be used for all AWS-CLI or Serverless.com commands.

--- a/Teachers_Guide/README.md
+++ b/Teachers_Guide/README.md
@@ -22,7 +22,7 @@ In-depth examination of this tools is also beyond the scope of this workshop, bu
 This command combines the AWS-CLI tools and JQ to get the ID of the API we just deployed above.
 
 ```sh
-export APIID=`aws apigateway get-rest-apis --region us-west-2 | jq '.items[] | select(.name | startswith("${STAGE}")) | .id' | sed 's/"//g'`
+export APIID=`aws apigateway get-rest-apis --region us-west-2 | jq --arg stage $STAGE '.items[] | select(.name | startswith($stage)) | .id' | sed 's/"//g'`
 echo $APIID
 ```
 
@@ -31,7 +31,7 @@ echo $APIID
 Now that we've got the Amazon assigned ID of our winner-api we can query it:
 
 ```sh
-wget -qO- "https://${APIID}.execute-api.us-west-2.amazonaws.com/${STAGE}/scores?role=creator&limit=2" | more
-wget -qO- "https://${APIID}.execute-api.us-west-2.amazonaws.com/${STAGE}/scores?role=photographer&limit=2" | more
-wget -qO- "https://${APIID}.execute-api.us-west-2.amazonaws.com/${STAGE}/contributions" | more
+curl -o - "https://${APIID}.execute-api.us-west-2.amazonaws.com/${STAGE}/scores?role=creator&limit=2" | more
+curl -o - "https://${APIID}.execute-api.us-west-2.amazonaws.com/${STAGE}/scores?role=photographer&limit=2" | more
+curl -o - "https://${APIID}.execute-api.us-west-2.amazonaws.com/${STAGE}/contributions" | more
 ```

--- a/Teachers_Guide/README.md
+++ b/Teachers_Guide/README.md
@@ -26,7 +26,7 @@ export APIID=`aws apigateway get-rest-apis --region us-west-2 | jq --arg stage $
 echo $APIID
 ```
 
-#### Use WGET to query your Winner API
+#### Use CURL to query your Winner API
 
 Now that we've got the Amazon assigned ID of our winner-api we can query it:
 

--- a/setup-aws-cli.sh
+++ b/setup-aws-cli.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+if which aws > /dev/null
+    then
+        echo "AWS CLI found."
+    else
+        echo "Installing AWS CLI"
+
+        if ! [ -f awscli-bundle.zip ]
+            then
+                curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+        fi
+
+        unzip -n awscli-bundle.zip
+        sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+
+        echo "Install complete; cleaning up bundle files."
+        rm -r ./awscli-bundle
+        rm ./awscli-bundle.zip
+fi

--- a/setup-jq.sh
+++ b/setup-jq.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+function install_homebrew {
+    if which brew > /dev/null
+        then
+            echo "Brew found. Making sure it's up to date..."
+            brew update
+        else
+            echo "Installing brew ..."
+            /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    fi
+}
+
+if which jq > /dev/null
+    then
+        echo "jq is installed."
+    else
+        install_homebrew
+        brew install jq
+fi

--- a/setup-nodejs.sh
+++ b/setup-nodejs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function open_node_download {
-    echo "Dohttps://nodejs.org/en/download/"
+    echo "https://nodejs.org/en/download/"
     echo "Attempting to open Node JS download page ... "
     sleep 3
     open "https://nodejs.org/en/download/"

--- a/setup-nodejs.sh
+++ b/setup-nodejs.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 function open_node_download {
-    echo "Opening Node JS download page ... "
-    echo "https://nodejs.org/en/download/"
+    echo "Dohttps://nodejs.org/en/download/"
+    echo "Attempting to open Node JS download page ... "
     sleep 3
     open "https://nodejs.org/en/download/"
     exit 1

--- a/setup-nodejs.sh
+++ b/setup-nodejs.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+function open_node_download {
+    echo "Opening Node JS download page ... "
+    echo "https://nodejs.org/en/download/"
+    sleep 3
+    open "https://nodejs.org/en/download/"
+    exit 1
+}
+
+if which node > /dev/null
+    then
+        echo "Node JS found, version: $(node -v)"
+    else
+        echo "Node JS missing."
+        open_node_download
+        exit 1
+fi
+
+NODE_MAJOR_VERSION=`node -v | sed -n "s/^v\([0-9]\).*/\1/p"`
+
+if [ $NODE_MAJOR_VERSION -lt 4 ]
+    then
+        echo "Node JS version $(node -v) is not sufficient. Please upgrade."
+        open_node_download
+        exit 1
+fi
+
+echo
+echo "Installing NPM dependencies ..."
+
+pushd Lesson2_CreateViewWithEventConsumer/winner-view
+npm install
+
+pushd Lesson3_PublicEndpointToAccessView/winner-api
+npm install


### PR DESCRIPTION
Initial version of some setup scripts that should help workshop participants get software tools installed more quickly. Includes:

1) Script to check Node JS version and install dependencies in sub-projects
2) Script to install AWS-CLI
3) Script to install JQ (JSON Query)

Scripts will also take the necessary steps of installing homebrew, if the user does not already have it installed, to deliver JQ.