### PR TITLE
Added popularity table, endpoint, and business logic

### DIFF
--- a/Lesson2_CreateViewWithEventConsumer/winner-view/serverless.yml
+++ b/Lesson2_CreateViewWithEventConsumer/winner-view/serverless.yml
@@ -24,6 +24,8 @@ functions:
         Ref: Contributions
       TABLE_SCORES_NAME:
         Ref: Scores
+      TABLE_POPULARITY_NAME:
+        Ref: Popularity
     events:
       - stream:
           arn: ${self:custom.stream}
@@ -117,6 +119,38 @@ resources:
             ProvisionedThroughput:
               ReadCapacityUnits: 1
               WriteCapacityUnits: 1
+    Popularity:
+      # Number of unique viewers in the past x time
+      Type: AWS::DynamoDB::Table
+      Properties:
+        AttributeDefinitions:
+          - AttributeName: productId
+            AttributeType: S
+          - AttributeName: purchaseCount
+            AttributeType: N
+          - AttributeName: type
+            AttributeType: S
+        KeySchema:
+          - AttributeName: productId
+            KeyType: HASH
+        ProvisionedThroughput:
+          ReadCapacityUnits: 1
+          WriteCapacityUnits: 1
+        TableName: ${opt:stage}-Popularity
+        GlobalSecondaryIndexes:
+          - IndexName: ProductsByCount
+            KeySchema:
+              - AttributeName: type
+                KeyType: HASH
+              - AttributeName: purchaseCount
+                KeyType: RANGE
+            Projection:
+              ProjectionType: INCLUDE
+              NonKeyAttributes:
+                - productName
+            ProvisionedThroughput:
+              ReadCapacityUnits: 1
+              WriteCapacityUnits: 1
     # Winner Role for the lambda to read from Kinesis, to write to Logs, and to read from and write to Dynamo DB
     WinnerReaderWriter:
       Type: AWS::IAM::Role
@@ -202,3 +236,13 @@ resources:
                       - '/'
                       - - 'arn:aws:dynamodb:${self:custom.private.region}:${self:custom.private.accountId}:table'
                         - Ref: Scores
+                - Effect: Allow
+                  Action:
+                    - 'dynamodb:Query'
+                    - 'dynamodb:UpdateItem'
+                    - 'dynamodb:GetItem'
+                  Resource:
+                    Fn::Join:
+                      - '/'
+                      - - 'arn:aws:dynamodb:${self:custom.private.region}:${self:custom.private.accountId}:table'
+                        - Ref: Popularity

--- a/Lesson3_PublicEndpointToAccessView/winner-api/popularity-items-schema.json
+++ b/Lesson3_PublicEndpointToAccessView/winner-api/popularity-items-schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "self": {
+    "vendor": "com.nordstrom",
+    "name": "popularity/items",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "productId":    { "type": "string" },
+      "purchaseCount":    { "type": "integer" },
+      "productName":    { "type": "string" },
+      "type":    { "type": "string" }
+    },
+    "required": [
+      "productName",
+      "purchaseCount"
+    ],
+    "additionalProperties": false
+  },
+  "additionalProperties": false
+}

--- a/Lesson3_PublicEndpointToAccessView/winner-api/popularity-request-schema.json
+++ b/Lesson3_PublicEndpointToAccessView/winner-api/popularity-request-schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "self": {
+    "vendor": "com.nordstrom",
+    "name": "popularity/request",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "path":                { "type": "string", "pattern": "^/popularity" },
+    "httpMethod":          { "type": "string", "pattern": "^GET" }
+  },
+  "required": [
+    "path",
+    "httpMethod"
+  ],
+  "additionalProperties": true
+}

--- a/Lesson3_PublicEndpointToAccessView/winner-api/serverless.yml
+++ b/Lesson3_PublicEndpointToAccessView/winner-api/serverless.yml
@@ -35,7 +35,17 @@ functions:
           path: scores
           method: get
           cors: true
-
+  popularity:
+    role:
+      Fn::GetAtt: [ WinnerApiPopularityReader, Arn ]
+    handler: winnerApi.popularity
+    environment:
+      TABLE_POPULARITY_NAME: ${opt:stage}-Popularity
+    events:
+      - http:
+          path: popularity
+          method: get
+          cors: true
 resources:
   Resources:
     # Log Group
@@ -48,6 +58,11 @@ resources:
       Type: AWS::Logs::LogGroup
       Properties:
         LogGroupName: /aws/lambda/${self:service}-${opt:stage}-scores
+        RetentionInDays: 3
+    PopularityLogGroup:
+      Type: AWS::Logs::LogGroup
+      Properties:
+        LogGroupName: /aws/lambda/${self:service}-${opt:stage}-popularity
         RetentionInDays: 3
     # Winner Tables Roles
     WinnerApiContributionsReader: # role for Contributions Lambda
@@ -132,3 +147,45 @@ resources:
                         - ${opt:stage}-Scores
                         - index
                         - ScoresByRole
+    WinnerApiPopularityReader: # role for Contributions Lambda
+      Type: AWS::IAM::Role
+      Properties:
+        Path: /
+        RoleName: ${opt:stage}WinnerApiPopularityReader
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action: sts:AssumeRole
+              Principal:
+                Service: lambda.amazonaws.com
+        ManagedPolicyArns:
+          - ${self:custom.private.teamPolicy}
+        Policies:
+          - PolicyName: CreateAndWriteToLogStream
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - 'logs:CreateLogStream'
+                    - 'logs:PutLogEvents'
+                  Resource:
+                    Fn::Join:
+                      - ':'
+                      - - Fn::GetAtt: [ PopularityLogGroup, Arn ]
+                        - '*'
+          - PolicyName: ReadFromPopularity
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                -  Effect: Allow
+                   Action:
+                     - 'dynamodb:Query'
+                   Resource:
+                    Fn::Join:
+                      - '/'
+                      - - 'arn:aws:dynamodb:${self:custom.private.region}:${self:custom.private.accountId}:table'
+                        - ${opt:stage}-Popularity
+                        - index
+                        - ProductsByCount


### PR DESCRIPTION
This implements the idea of "popularity" for a product, which is calculated by # of purchases.

- Upon product registration, the new 'popularity' table is populated with some metadata.
- Upon a purchase event, the "purchaseCount" field is updated for the product.
- The endpoint returns the top 3 most popular items.

**A caveat**: if the product already existed in the system previous to this implementation, it won't ever be grabbed by the popularity endpoint as it requires a the productName field to be filled out, which is specifically set upon registration of a product.