### PR TITLE
Adjusted sed regex to accept multiple major version numbers

### DIFF
--- a/setup-nodejs.sh
+++ b/setup-nodejs.sh
@@ -16,7 +16,7 @@ if which node > /dev/null
         exit 1
 fi
 
-NODE_MAJOR_VERSION=`node -v | sed -n "s/^v\([0-9]\).*/\1/p"`
+NODE_MAJOR_VERSION=`node -v | sed -n "s/^v\([[:digit:]]*\).*/\1/p"`
 
 if [ $NODE_MAJOR_VERSION -lt 4 ]
     then


### PR DESCRIPTION
Fixes #56 where only the first digit of the Node major version was compared with `4`.

Using the `*` operator the regex is modified to select multiple numbers before the first `.`.